### PR TITLE
Module's exports in the top of the file

### DIFF
--- a/1.js
+++ b/1.js
@@ -5,6 +5,8 @@ const createRequest = require('./createRequest');
 // $FlowFixMe
 const identityService = require('./identityService');
 
+module.exports = pub;
+
 /*::
 import type {
     RequestParams,
@@ -69,5 +71,3 @@ const pub/*: ({| ...CreateRequestOptions, gatewayConfig: GatewayConfig |}) => (R
         };
     }
 }
-
-module.exports = pub;


### PR DESCRIPTION
It's always nice to see module's definition (what functions it exports) right in the beginning of the file, so that one doesn't have to scroll all the way down the file to see it.

But to be able to have the exports in the beginning of the file, all functions needs to be declared using Function Declaration.

To "run" the compiler run the following command:
```sh
$> make
```

Instructions:
1) in master: make sure it compiles
2) in this branch: make sure it doesn't compile
3) branch out from this branch (not from master, from this branch!)
4) fix the problem in your new branch, it must compile
5) create a PR from your new branch to this branch
